### PR TITLE
04_テストコード修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 
 # Ignore .idea files
 .idea
+
+# Ignore installed gem files.
+/vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -316,4 +318,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.0.1
+   2.2.11

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+    association :project
 
     trait :add do
       status { :done }

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+
+    trait :add do
+      status { :done }
+      completion_date { Time.current.yesterday }
+    end
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     deadline { Random.rand(from..to) }
     association :project
 
-    trait :add do
+    trait :done do
       status { :done }
       completion_date { Time.current.yesterday }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  include ApplicationHelper
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -76,9 +76,9 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_task_path(project, task)
       end
 
+      let(:task_add) { create(:task, :add) }
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
-        task = create(:task, :add, project_id: project.id)
         visit edit_project_task_path(project, task)
         select 'todo', from: 'Status'
         click_button 'Update Task'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -91,9 +91,9 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task削除' do
     context '正常系' do
+      let!(:task) { create(:task) }
       # FIXME: テストが失敗するので修正してください
       it 'Taskが削除されること' do
-        task
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -2,23 +2,23 @@ require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
   describe 'Task一覧' do
+      let(:project) { create(:project) }
+      let!(:task) { create(:task, project_id: project.id) }
+
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_path(project)
         click_link 'View Todos'
+        switch_to_window(windows.last)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)
@@ -27,10 +27,11 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task新規作成' do
+    let(:project) { create(:project) }
+
     context '正常系' do
       it 'Taskが新規作成されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
         visit project_tasks_path(project)
         click_link 'New Task'
         fill_in 'Title', with: 'test'
@@ -43,11 +44,12 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task詳細' do
+    let(:project) { create(:project) }
+    let(:task) { create(:task, project_id: project.id) }
+
     context '正常系' do
       it 'Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_task_path(project, task)
         expect(page).to have_content(task.title)
         expect(page).to have_content(task.status)
@@ -58,23 +60,22 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task編集' do
+    let(:project) { create(:project) }
+    let(:task) { create(:task, project_id: project.id) }
+
     context '正常系' do
-      xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content(Time.current.strftime('%Y-%m-%d'))
+        expect(find('.task_list')).to have_content(Time.current.short_time(Time.current))
         expect(current_path).to eq project_tasks_path(project)
       end
 
       it 'ステータスを完了にした場合、Taskの完了日に今日の日付が登録されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         select 'done', from: 'Status'
         click_button 'Update Task'
@@ -85,8 +86,7 @@ RSpec.describe 'Task', type: :system do
 
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
+        task = create(:task, :add, project_id: project.id)
         visit edit_project_task_path(project, task)
         select 'todo', from: 'Status'
         click_button 'Update Task'
@@ -98,15 +98,17 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task削除' do
+    let(:project) { create(:project) }
+    let(:task) { create(:task, project_id: project.id) }
+
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      xit 'Taskが削除されること' do
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+      it 'Taskが削除されること' do
+        task
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept
-        expect(page).not_to have_content task.title
+        expect(find('.task_list')).not_to have_content(task.title)
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
-  describe 'Task一覧' do
-      let(:project) { create(:project) }
-      let!(:task) { create(:task) }
+  let(:project) { create(:project) }
+  let(:task) { create(:task) }
 
+  describe 'Task一覧' do
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
@@ -27,8 +27,6 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task新規作成' do
-    let(:project) { create(:project) }
-
     context '正常系' do
       it 'Taskが新規作成されること' do
         # TODO: ローカル変数ではなく let を使用してください
@@ -44,9 +42,6 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task詳細' do
-    let(:project) { create(:project) }
-    let(:task) { create(:task) }
-
     context '正常系' do
       it 'Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
@@ -60,9 +55,6 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task編集' do
-    let(:project) { create(:project) }
-    let(:task) { create(:task) }
-
     context '正常系' do
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
@@ -98,9 +90,6 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task削除' do
-    let(:project) { create(:project) }
-    let(:task) { create(:task) }
-
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
       it 'Taskが削除されること' do

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Task', type: :system do
   describe 'Task一覧' do
       let(:project) { create(:project) }
-      let!(:task) { create(:task, project_id: project.id) }
+      let!(:task) { create(:task) }
 
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
@@ -45,7 +45,7 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task詳細' do
     let(:project) { create(:project) }
-    let(:task) { create(:task, project_id: project.id) }
+    let(:task) { create(:task) }
 
     context '正常系' do
       it 'Taskが表示されること' do
@@ -61,7 +61,7 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     let(:project) { create(:project) }
-    let(:task) { create(:task, project_id: project.id) }
+    let(:task) { create(:task) }
 
     context '正常系' do
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
@@ -99,7 +99,7 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task削除' do
     let(:project) { create(:project) }
-    let(:task) { create(:task, project_id: project.id) }
+    let(:task) { create(:task) }
 
     context '正常系' do
       # FIXME: テストが失敗するので修正してください

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_task_path(project, task)
       end
 
-      let(:task_add) { create(:task, :add) }
+      let(:task_done) { create(:task, :done) }
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
         visit edit_project_task_path(project, task)


### PR DESCRIPTION
- ローカル変数で定義していたprojectとtaskをletを使って書き換える。

```
project = FactoryBot.create(:project)
task = FactoryBot.create(:task, project_id: project.id)
=> let(:project) { create(:project) }
      let(:task) { create(:task, project_id: project.id) }
```
letを使うことで定義を共通化することができる。

- 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' 
スクリーンショットを確認するとTaskの情報が入っていなかったので、`let(:task)`を`let!(:task)`とした。
let!とすることでitの行が実行される直前に変数が呼び出されなくても使用できるようになる。

- 'Taskを編集した場合、一覧画面で編集後の内容が表示されること'
スクリーンショットを見るとちゃんとテスト結果は出力されていた。
テストが失敗するのが`expect(find('.task_list')).to have_content(Time.current.strftime('%Y-%m-%d'))`
ここだったので`('%Y-%m-%d')`この部分に注目した。
理想とする結果が1/20 10:10のような形式なので`('%-m/%d %H:%M')`に変えるとパスする。
指定の要件にビューでも使っているshort_timeメソッドを使うよう書いてあったので、
`(Time.current.short_time(Time.current))`メソッドを使うように書き換えた。
そしてRSpecでもこのメソッドを使えるようにするために、rails_helper.rbに`include ApplicationHelper`を追記する。

- FactoryBotのtraitを利用してください
(tasks.rb)
```
FactoryBot.define do
  factory :task do
    title { 'Task' }
    status { rand(2) }
    from = Date.parse("2019/08/01")
    to   = Date.parse("2019/12/31")
    deadline { Random.rand(from..to) }

    trait :add do
      status { :done }
      completion_date { Time.current.yesterday }
    end
  end
end
```
traitを追加することで、もともとあるfactory:taskのテストデータを上書きすることができるようになる。
これをテストケースで使うときは、`task = create(:task, :add, project_id: project.id)`と書くだけでOK
` project_id: project.id`をつけないとテストに失敗する。

- 'Taskが削除されること'
byebugなので確認するとtaskが作成されていないので、taskを追記する。
`expect(page).to have_content(task.title)`この表記だと、FactoryBotで作成されるtask.titleの名前が、
そのページのどこかに存在している場合に、テストが十敗してしまうので、
`expect(find('.task_list')).not_to have_content(task.title)`このように書き換える。
`('.task_list')`はクラス名。範囲を狭くすることができる。

テスト結果

https://i.gyazo.com/a8c89b050321a1507279e3e6f4987cfc.png


